### PR TITLE
Install enterprise edition instead of community edition

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -132,7 +132,7 @@ ynh_script_progression --message="Install OnlyOffice..."
 # restart NGINX and the whole webadmin and maybe even the YunoHost command
 # running the install...
 
-ynh_exec_warn_less ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="onlyoffice-documentserver" --key="https://download.onlyoffice.com/GPG-KEY-ONLYOFFICE"
+ynh_exec_warn_less ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="onlyoffice-documentserver-ee" --key="https://download.onlyoffice.com/GPG-KEY-ONLYOFFICE"
 
 #=================================================
 # ADD A CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -94,7 +94,7 @@ echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-
 #=================================================
 ynh_script_progression --message="Reinstalling OnlyOffice..."
 
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="onlyoffice-documentserver" --key="https://download.onlyoffice.com/GPG-KEY-ONLYOFFICE"
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="onlyoffice-documentserver-ee" --key="https://download.onlyoffice.com/GPG-KEY-ONLYOFFICE"
 
 #=================================================
 # RESTORE THE CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -136,7 +136,7 @@ ynh_remove_extra_repo --name="$app" # backward compat
 # apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 
 # ynh_remove_app_dependencies
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="onlyoffice-documentserver" --key="https://download.onlyoffice.com/GPG-KEY-ONLYOFFICE"
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="onlyoffice-documentserver-ee" --key="https://download.onlyoffice.com/GPG-KEY-ONLYOFFICE"
 
 
 #=================================================


### PR DESCRIPTION
## Solution
Installing enterprise edition will make possible to put a licence key and get pro features.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
